### PR TITLE
#154388837 confirm_delete_modal

### DIFF
--- a/client/src/js/components/DashBoard/MyRecipes/index.jsx
+++ b/client/src/js/components/DashBoard/MyRecipes/index.jsx
@@ -176,6 +176,11 @@ class RecipeAdmin extends React.Component {
   }
 }
 
+RecipeAdmin.defaultProps = {
+  pageCount: 0,
+  isLoadingRecipe: false
+};
+
 
 RecipeAdmin.propTypes = {
   apiCreateRecipe: PropTypes.func.isRequired,
@@ -185,8 +190,8 @@ RecipeAdmin.propTypes = {
   onViewRecipe: PropTypes.func.isRequired,
   myRecipes: PropTypes.arrayOf(PropTypes.any).isRequired,
   errorMessage: PropTypes.string.isRequired,
-  pageCount: PropTypes.number.isRequired,
-  isLoadingRecipe: PropTypes.bool.isRequired
+  pageCount: PropTypes.number,
+  isLoadingRecipe: PropTypes.bool
 };
 
 RecipeAdmin.contextTypes = {

--- a/client/src/js/components/DashBoard/RecipeDetails/Content/Reviews.jsx
+++ b/client/src/js/components/DashBoard/RecipeDetails/Content/Reviews.jsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
+import toastr from 'toastr';
+import { confirmAlert } from 'react-confirm-alert';
 import moment from 'moment';
 import AddReviewForm from '../../../Partials/AddReviewForm';
 import { apiDeleteRecipeReview } from '../../../../actions/recipe';
@@ -22,7 +24,6 @@ class Reviews extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
-      modal: false
     };
     this.onDelete = this.onDelete.bind(this);
   }
@@ -34,7 +35,14 @@ class Reviews extends React.Component {
    * @memberof RecipeAdmin
    */
   onDelete(id) {
-    this.props.apiDeleteRecipeReview(id);
+    confirmAlert({
+      title: 'Confirm',
+      message: 'Are you sure you want to do this.',
+      confirmLabel: 'Confirm',
+      cancelLabel: 'Cancel',
+      onConfirm: () => this.props.apiDeleteRecipeReview(id),
+      onCancel: () => toastr.success('thanks'),
+    });
   }
 
   /**
@@ -93,42 +101,11 @@ class Reviews extends React.Component {
   }
 }
 
-// const Reviews = props => (
-//   <div
-//     className={props.activeTab.name === 'Reviews' ?
-//     'tab-pane fade show active' :
-//     'tab-pane fade'}
-//     id="reviews"
-//     role="tabpanel"
-//     aria-labelledby="reviews-tab"
-//   >
-//     <AddReviewForm
-//       recipeId={props.recipeId}
-//     />
-//     <ul className={props.activeTab.name === 'Reviews' ?
-//     'tab-pane fade show active' :
-//     'tab-pane fade'}
-//     >
-//       {props.activeTab.name === 'Reviews' ?
-//       props.reviewedRecipe.Reviews.map(review =>
-//       (
-//         <li key={review.id} className="list-group-item">
-//           <h6>{review.User.userName}
-//             {moment(new Date(review.createdAt)).fromNow()}
-//           </h6>
-//           {review.reviews}
-
-//         </li>))
-//       : 'no-reviews' }
-//     </ul>
-//   </div>
-// );
-
-
 Reviews.propTypes = {
   activeTab: PropTypes.objectOf(PropTypes.any).isRequired,
   recipeId: PropTypes.number,
   reviewedRecipe: PropTypes.objectOf(String).isRequired,
+  apiDeleteRecipeReview: PropTypes.func.isRequired
 };
 
 Reviews.defaultProps = {

--- a/client/src/js/components/DashBoard/RecipeDetails/index.jsx
+++ b/client/src/js/components/DashBoard/RecipeDetails/index.jsx
@@ -190,7 +190,6 @@ MyRecipe.propTypes = {
  * @returns {void}
  */
 function mapStateToProps(state) {
-  console.log('recipestate', state);
   return {
     recipe: state.recipe.recipe,
   };

--- a/client/src/js/components/Partials/AdminCardItem.jsx
+++ b/client/src/js/components/Partials/AdminCardItem.jsx
@@ -1,5 +1,9 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
+import Proptypes from 'prop-types';
+import toastr from 'toastr';
+import { confirmAlert } from 'react-confirm-alert';
+import 'react-confirm-alert/src/react-confirm-alert.css';
 import EditRecipeModal from '../Partials/EditRecipeModal';
 
 const defaultImage = require('../../../assets/images/no_image.png');
@@ -34,7 +38,14 @@ class AdminCardItem extends React.Component {
    * @memberof AdminCardItem
    */
   onDelete() {
-    this.props.deleteRecipe(this.props.recipe.id);
+    confirmAlert({
+      title: 'Confirm',
+      message: 'Are you sure you want to do this.',
+      confirmLabel: 'Confirm',
+      cancelLabel: 'Cancel',
+      onConfirm: () => this.props.deleteRecipe(this.props.recipe.id),
+      onCancel: () => toastr.success('thanks'),
+    });
   }
 
   /**
@@ -101,7 +112,7 @@ class AdminCardItem extends React.Component {
                     role="button"
                     tabIndex="-1"
                     onKeyPress={this.onKeyPress}
-                    onClick={() => this.onDelete()}
+                    onClick={this.onDelete}
                   />
                 </span>
               </div>
@@ -112,5 +123,10 @@ class AdminCardItem extends React.Component {
     );
   }
 }
+AdminCardItem.propTypes = {
+  deleteRecipe: Proptypes.func.isRequired,
+  editRecipe: Proptypes.func.isRequired,
+  recipe: Proptypes.objectOf(Proptypes.any).isRequired
+};
 
 export default AdminCardItem;

--- a/package-lock.json
+++ b/package-lock.json
@@ -10709,6 +10709,11 @@
         "object-assign": "4.1.1"
       }
     },
+    "react-confirm-alert": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/react-confirm-alert/-/react-confirm-alert-1.0.8.tgz",
+      "integrity": "sha1-E8u889mSokWzFe8YzCA4JVbj8DM="
+    },
     "react-dom": {
       "version": "16.0.0",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
     "promise": "^8.0.1",
     "prop-types": "^15.6.0",
     "react": "^16.0.0",
+    "react-confirm-alert": "^1.0.8",
     "react-dom": "^16.0.0",
     "react-dropzone": "^4.2.3",
     "react-hot-loader": "^1.3.0",


### PR DESCRIPTION
#### What does this PR do?
- Displays modal to confirm delete
#### Description of Task to be completed?
- When a user choose to delete a recipe, a modal pops up to confirm deletion
#### How should this be manually tested?
- on the admin card item, click on the delete icon. A modal to either delete or cancel will pop up
#### What are the relevant pivotal tracker stories?
https://www.pivotaltracker.com/story/show/154388837
#### Screenshots (if appropriate)
<img width="1425" alt="screen shot 2018-01-17 at 11 29 30" src="https://user-images.githubusercontent.com/17340003/35038868-6baa2748-fb7c-11e7-976f-8aa5c997bf4a.png">
